### PR TITLE
Manual gap selection: Added continuous gap selection

### DIFF
--- a/include/dynamic_gap/Planner.h
+++ b/include/dynamic_gap/Planner.h
@@ -16,6 +16,7 @@
 
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/PoseArray.h>
+#include <geometry_msgs/PointStamped.h>
 #include <sensor_msgs/LaserScan.h>
 // #include <std_msgs/Header.h>
 #include <nav_msgs/Odometry.h>
@@ -148,12 +149,14 @@ namespace dynamic_gap
             struct ManualCandidate
             {
                 int display_id;
-                int traj_flag;   // GAP, UNGAP, IDLING
+                int traj_flag;   // GAP, UNGAP, IDLING, 
                 int local_idx;
+                geometry_msgs::PoseArray path_odom_frame; // full trajectory path in odom frame
             };
 
             ros::Subscriber manualTrajSelectionSub_;
             ros::Publisher manualCandidateMarkerPub_;
+            ros::Subscriber rvizPublishPointSubsciber_; //for manuel_gap_selection click to point
 
             int selectedManualCandidateId_ = -1;
             bool manualSelectionMode_ = true;
@@ -162,6 +165,9 @@ namespace dynamic_gap
             boost::mutex manualSelectionMutex_;
 
             void manualTrajSelectionCB(const std_msgs::Int32::ConstPtr& msg);
+
+            //callback function for RViz publish point subscriber
+            void rvizPublishPointSubsciberCB(const geometry_msgs::PointStamped::ConstPtr& msg);
 
             void publishManualCandidateMarkers(const std::vector<Trajectory>& gapTrajs,
                                             const std::vector<Trajectory>& ungapTrajs,

--- a/src/Planner.cpp
+++ b/src/Planner.cpp
@@ -664,19 +664,23 @@ void Planner::jointPoseAccCB(const nav_msgs::Odometry::ConstPtr & rbtOdomMsg,
         float minDist = std::numeric_limits<float>::infinity();
         int nearestCandidateId = -1;
 
+        geometry_msgs::Pose pose;
+
         for (const ManualCandidate& c : currentManualCandidates_)
         {
-            for (const geometry_msgs::Pose& pose : c.path_odom_frame.poses)
+            if (c.path_odom_frame.poses.empty())
             {
-                float dx = pose.position.x - clickedPointOdomFrame.point.x;
-                float dy = pose.position.y - clickedPointOdomFrame.point.y;
-                float dist = sqrt(pow(dx, 2) + pow(dy, 2));
-
-                if (dist < minDist)
-                {
-                    minDist = dist;
-                    nearestCandidateId = c.display_id;
-                }
+                continue;
+            }
+                
+            pose = c.path_odom_frame.poses.back();
+            float dx = pose.position.x - clickedPointOdomFrame.point.x;
+            float dy = pose.position.y - clickedPointOdomFrame.point.y;
+            float dist = sqrt(pow(dx, 2) + pow(dy, 2));
+            if (dist < minDist)
+            {
+                minDist = dist;
+                nearestCandidateId = c.display_id;
             }
         }
 
@@ -1467,7 +1471,7 @@ void Planner::jointPoseAccCB(const nav_msgs::Odometry::ConstPtr & rbtOdomMsg,
 
             ROS_INFO_STREAM_NAMED("Planner", "[pickTraj()]");
             
-            // int lowestCostTrajIdx = -1;        
+            // int lowestCostTrajIdx = -1;       g 
             
             int numUngapTrajs = ungapTrajs.size();
             int numIdlingTrajs = idlingTrajs.size();

--- a/src/Planner.cpp
+++ b/src/Planner.cpp
@@ -123,6 +123,8 @@ namespace dynamic_gap
         manualTrajSelectionSub_ = nh_.subscribe("/manual_traj_selection", 1,
                                         &Planner::manualTrajSelectionCB, this);
 
+        rvizPublishPointSubsciber_ = nh_.subscribe("/gap_selection_point", 1, &Planner::rvizPublishPointSubsciberCB, this); //initlize the pubcriber for the publish point RVIz button on manuel trajectroy selction
+
         manualCandidateMarkerPub_ = nh_.advertise<visualization_msgs::MarkerArray>(
             "/manual_candidate_markers", 1);
 
@@ -645,6 +647,50 @@ void Planner::jointPoseAccCB(const nav_msgs::Odometry::ConstPtr & rbtOdomMsg,
                                         << selectedManualCandidateId_);
     }
 
+    //callback function, updates 
+    void Planner::rvizPublishPointSubsciberCB(const geometry_msgs::PointStamped::ConstPtr& msg) {
+        boost::mutex::scoped_lock lock(manualSelectionMutex_);
+        
+        ROS_INFO_STREAM_NAMED("Planner", "[rvizPublishPointSubsciberCB] received point: (" << msg->point.x << ", " << msg->point.y << ")");
+        
+        if (!haveTFs_)
+            return;
+
+        // transform clicked point from map frame to odom frame
+        geometry_msgs::PointStamped clickedPointOdomFrame;
+        tf2::doTransform(*msg, clickedPointOdomFrame, map2odom_);
+
+        // find nearest candidate path pose to clicked point
+        float minDist = std::numeric_limits<float>::infinity();
+        int nearestCandidateId = -1;
+
+        for (const ManualCandidate& c : currentManualCandidates_)
+        {
+            for (const geometry_msgs::Pose& pose : c.path_odom_frame.poses)
+            {
+                float dx = pose.position.x - clickedPointOdomFrame.point.x;
+                float dy = pose.position.y - clickedPointOdomFrame.point.y;
+                float dist = sqrt(pow(dx, 2) + pow(dy, 2));
+
+                if (dist < minDist)
+                {
+                    minDist = dist;
+                    nearestCandidateId = c.display_id;
+                }
+            }
+        }
+
+        ROS_INFO_STREAM_NAMED("Planner", "[rvizPublishPointSubsciberCB] finished, selected candidate: " << selectedManualCandidateId_ << " in " << minDist << "m");
+
+        if (nearestCandidateId >= 0)
+        {
+            selectedManualCandidateId_ = nearestCandidateId;
+            ROS_INFO_STREAM_NAMED("Planner", "[rvizPublishPointSubsciberCB] selected candidate: " << selectedManualCandidateId_ << " (dist: " << minDist << ")");
+        } else {
+            ROS_WARN_STREAM_NAMED("Planner", "[rvizPublishPointSubsciberCB] no candidate found");
+        }
+    }
+
     void Planner::publishManualCandidateMarkers(const std::vector<Trajectory>& gapTrajs,
                                             const std::vector<Trajectory>& ungapTrajs,
                                             const std::vector<Trajectory>& idlingTrajs)
@@ -672,6 +718,7 @@ void Planner::jointPoseAccCB(const nav_msgs::Odometry::ConstPtr & rbtOdomMsg,
             c.display_id = display_id;
             c.traj_flag = traj_flag;
             c.local_idx = local_idx;
+            c.path_odom_frame = traj.getPathOdomFrame();
             currentManualCandidates_.push_back(c);
 
             const geometry_msgs::Pose& terminal_pose =
@@ -1567,6 +1614,7 @@ void Planner::jointPoseAccCB(const nav_msgs::Odometry::ConstPtr & rbtOdomMsg,
                                                 Gap * incomingGap) 
     {
         // publishToMpc_ = true;
+        ROS_INFO_STREAM_NAMED("Planner", "[changeTrajectoryHelper] trajectory switch " << trajectoryChangeCount_ << " to trajFlag: " << trajFlag);
         
         if (switchToIncoming) 
         {


### PR DESCRIPTION
I added a subscriber in planner .cpp and .h that subscribes to the gap_selection_point topic. This topic receives geometry_msgs/PointStamped messages. When the position is published, we calculate the closest gap from that position and set gap/trajectory to the current trajectory. This can be used in two ways: the publish point button when publishing to gap_selection_point, or another RViz plugin I created called continuous_gap_selection that publishes the cursor's position whenever it moves to gap_selection_point. Note that the position is only published when the cursor moves, meaning if the cursor is stationary, no position is published. Currently, the gap number is highlighted when that position is chosen. For full continuous control, one must pull the ContinousGapSelectionTool from arena_rosnav for RViz plugin. 